### PR TITLE
Include minimap2 as alignment method

### DIFF
--- a/TELR_input.py
+++ b/TELR_input.py
@@ -39,10 +39,17 @@ def get_args():
 
     # optional
     optional.add_argument(
+        "-m",
+        "--method",
+        type=str,
+        help="method for read alignment, please provide 'nglmr' or 'minimap2' (default = 'nglmr')",
+        required=False,
+    )
+    optional.add_argument(
         "-x",
         "--presets",
         type=str,
-        help="parameter presets for different sequencing technologies (default = 'pacbio')",
+        help="parameter presets for different sequencing technologies, please provide 'ont' or 'pacbio' (default = 'pacbio')",
         required=False,
     )
     optional.add_argument(
@@ -111,6 +118,9 @@ def get_args():
         print(e)
         logging.exception("Can not open input file: " + args.library)
         sys.exit(1)
+
+    if args.method is None:
+        args.method = "nglmr"
 
     if args.presets is None:
         args.presets = "pacbio"

--- a/docs/02_Usage.md
+++ b/docs/02_Usage.md
@@ -18,9 +18,13 @@ required arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  -m METHOD, --method METHOD
+                        method for read alignment, please provide 'nglmr' or
+                        'minimap2' (default = 'nglmr')
   -x PRESETS, --presets PRESETS
                         parameter presets for different sequencing
-                        technologies (default = 'pacbio')
+                        technologies, please provide 'ont' or 'pacbio'
+                        (default = 'pacbio')
   -p POLISH, --polish POLISH
                         rounds of contig polishing (default = 1)
   -o OUT, --out OUT     directory to output data (default = '.')
@@ -45,7 +49,8 @@ python3 telr.py -i (--reads) <reads in fasta/fastq format or read alignments in 
 
 ## Optional arguments
 In addition to the required program options listed above, there are some optional arguments. The full list of program options with descriptions can also be obtained by running `telr.py -h`.
-- `-x (--presets) <arg>` Preset for different sequencing technologies (default = 'pacbio').
+- `-m (--method) <arg>` Method for read alignment, please provide 'nglmr' or or 'minimap2' (default = 'nglmr').
+- `-x (--presets) <arg>` Preset for different sequencing technologies, please provide 'ont' or 'pacbio' (default = 'pacbio').
 - `-p (--polish) <int>` Rounds of contig polishing using polisher from [wtdbg2](https://github.com/ruanjue/wtdbg2) (default = 1).
 - `-o (--out) <arg>` Output directory (default = '.').
 - `-t (--thread) <int>` Maximum cpu threads to use (default = '1').

--- a/telr.py
+++ b/telr.py
@@ -48,7 +48,7 @@ def main():
     bam = os.path.join(tmp_dir, sample_name + "_sort.bam")
     if not skip_alignment:
         alignment(
-            bam, fasta, reference, tmp_dir, sample_name, args.thread, args.presets
+            bam, fasta, reference, tmp_dir, sample_name, args.thread, args.method, args.presets
         )
     else:
         sort_index_bam(reads, bam, args.thread)


### PR DESCRIPTION
- In this update, users can optionally use minimap2 as method to align raw reads to the reference genome (default method is `NGLMR`).