### PR TITLE
Add flye

### DIFF
--- a/TELR_assembly.py
+++ b/TELR_assembly.py
@@ -11,8 +11,8 @@ from TELR_utility import mkdir, check_exist, format_time, create_loci_set
 
 
 def get_local_contigs(
-    asm_method,
-    polish_method,
+    assembler,
+    polisher,
     contig_dir,
     vcf_parsed,
     out,
@@ -56,8 +56,8 @@ def get_local_contigs(
                 contig_name,
                 thread_asm,
                 presets,
-                asm_method,
-                polish_method,
+                assembler,
+                polisher,
                 polish_iterations,
             ]
             asm_pa_list.append(asm_pa)
@@ -107,12 +107,12 @@ def run_assembly_polishing(args):
     contig_name = args[2]
     thread = args[3]
     presets = args[4]
-    asm_method = args[5]
-    polish_method = args[6]
+    assembler = args[5]
+    polisher = args[6]
     polish_iterations = args[7]
 
     # run assembly
-    if asm_method == "wtdbg2":
+    if assembler == "wtdbg2":
         asm_cns = run_wtdbg2_assembly(reads, asm_dir, contig_name, thread, presets)
     else:
         asm_cns = run_flye_assembly(reads, asm_dir, contig_name, thread, presets)
@@ -123,7 +123,7 @@ def run_assembly_polishing(args):
 
     # run polishing
     if polish_iterations > 0:
-        if polish_method == "wtdbg2":
+        if polisher == "wtdbg2":
             asm_cns = run_wtdbg2_polishing(
                 asm_cns, reads, thread, polish_iterations, presets
             )

--- a/TELR_assembly.py
+++ b/TELR_assembly.py
@@ -5,13 +5,14 @@ import shutil
 import time
 import logging
 from Bio import SeqIO
-from multiprocessing import Process, Pool
+from multiprocessing import Pool
 import pysam
-from TELR_utility import mkdir, check_exist, format_time
+from TELR_utility import mkdir, check_exist, format_time, create_loci_set
 
 
-def local_assembly(
-    method,
+def get_local_contigs(
+    asm_method,
+    polish_method,
     contig_dir,
     vcf_parsed,
     out,
@@ -22,13 +23,13 @@ def local_assembly(
     presets,
     polish_iterations,
 ):
-    """Perform local assembly using reads from parsed VCF file"""
+    """Perform local assembly using reads from parsed VCF file in parallel"""
 
     # Prepare reads used for local assembly and polishing
     sv_reads_dir = os.path.join(out, "sv_reads")
 
     try:
-        prep_assembly(
+        prep_assembly_inputs(
             vcf_parsed, out, sample_name, bam, raw_reads, sv_reads_dir, read_type="sv"
         )
     except Exception as e:
@@ -55,6 +56,8 @@ def local_assembly(
                 contig_name,
                 thread_asm,
                 presets,
+                asm_method,
+                polish_method,
                 polish_iterations,
             ]
             asm_pa_list.append(asm_pa)
@@ -63,32 +66,307 @@ def local_assembly(
     logging.info("Perform local assembly of non-reference TE loci...")
     start_time = time.time()
 
-    if method == "wtdbg2":
-        try:
-            pool = Pool(processes=thread)
-            pool.map(run_wtdbg2, asm_pa_list)
-            pool.close()
-            pool.join()
-        except Exception as e:
-            print(e)
-            print("Local assembly failed, exiting...")
-            sys.exit(1)
-    else:
-        try:
-            pool = Pool(processes=thread)
-            pool.map(run_flye, asm_pa_list)
-            pool.close()
-            pool.join()
-        except Exception as e:
-            print(e)
-            print("Local assembly failed, exiting...")
-            sys.exit(1)
+    try:
+        pool = Pool(processes=thread)
+        contig_list = pool.map(run_assembly_polishing, asm_pa_list)
+        pool.close()
+        pool.join()
+    except Exception as e:
+        print(e)
+        print("Local assembly failed, exiting...")
+        sys.exit(1)
 
     proc_time = time.time() - start_time
+
+    # merge all contigs
+    assembly_passed_loci = set()
+    merged_contigs = os.path.join(out, sample_name + ".contigs.fa")
+    with open(merged_contigs, "w") as merged_output_handle:
+        for contig in contig_list:
+            if check_exist(contig):
+                contig_name = os.path.basename(contig).replace(".cns.fa", "")
+                assembly_passed_loci.add(contig_name)
+                parsed_contig = os.path.join(contig_dir, contig_name + ".cns.ctg1.fa")
+                with open(contig, "r") as input:
+                    records = SeqIO.parse(input, "fasta")
+                    for record in records:
+                        if record.id == "ctg1" or record.id == "contig_1":
+                            record.id = contig_name
+                            record.description = "len=" + str(len(record.seq))
+                            SeqIO.write(record, merged_output_handle, "fasta")
+                            with open(parsed_contig, "w") as parsed_output_handle:
+                                SeqIO.write(record, parsed_output_handle, "fasta")
+
     logging.info("Local assembly finished in " + format_time(proc_time))
+    return merged_contigs, assembly_passed_loci
 
 
-def prep_assembly(
+def run_assembly_polishing(args):
+    reads = args[0]
+    asm_dir = args[1]
+    contig_name = args[2]
+    thread = args[3]
+    presets = args[4]
+    asm_method = args[5]
+    polish_method = args[6]
+    polish_iterations = args[7]
+
+    # run assembly
+    if asm_method == "wtdbg2":
+        asm_cns = run_wtdbg2_assembly(reads, asm_dir, contig_name, thread, presets)
+    else:
+        asm_cns = run_flye_assembly(reads, asm_dir, contig_name, thread, presets)
+
+    if not check_exist(asm_cns):
+        print("assembly failed")
+        return None
+
+    # run polishing
+    if polish_iterations > 0:
+        if polish_method == "wtdbg2":
+            asm_cns = run_wtdbg2_polishing(
+                asm_cns, reads, thread, polish_iterations, presets
+            )
+        else:
+            asm_cns = run_flye_polishing(
+                asm_cns, reads, asm_dir, contig_name, thread, polish_iterations, presets
+            )
+
+    if check_exist(asm_cns):
+        return asm_cns
+    else:
+        return None
+
+
+def run_flye_polishing(
+    asm_cns, reads, asm_dir, contig_name, thread, polish_iterations, presets
+):
+    """Run Flye polishing"""
+    if presets == "pacbio":
+        presets_flye = "--pacbio-raw"
+    else:
+        presets_flye = "--nano-raw"
+
+    tmp_out_dir = os.path.join(asm_dir, contig_name)
+    mkdir(tmp_out_dir)
+    try:
+        subprocess.call(
+            [
+                "flye",
+                "--polish-target",
+                asm_cns,
+                presets_flye,
+                reads,
+                "--out-dir",
+                tmp_out_dir,
+                "--thread",
+                str(thread),
+                "--iterations",
+                str(polish_iterations),
+            ]
+        )
+    except Exception as e:
+        print(e)
+        print("Polishing failed, exiting...")
+        return None
+
+    # rename contig file
+    polished_contig = os.path.join(
+        tmp_out_dir, "polished_" + str(polish_iterations) + ".fasta"
+    )
+    if check_exist(polished_contig):
+        os.rename(polished_contig, asm_cns)
+        shutil.rmtree(tmp_out_dir)
+        return asm_cns
+    else:
+        return None
+
+
+def run_wtdbg2_polishing(asm_cns, reads, threads, polish_iterations, presets):
+    """Run wtdbg2 polishing"""
+    if presets == "pacbio":
+        presets_minimap2 = "map-pb"
+    else:
+        presets_minimap2 = "map-ont"
+
+    # polish consensus
+    threads = str(min(threads, 4))
+    bam = asm_cns + ".bam"
+    k = 0
+    while True:
+        # align reads to contigs
+
+        command = (
+            "minimap2 -t "
+            + threads
+            + " -ax "
+            + presets_minimap2
+            + " -r2k "
+            + asm_cns
+            + " "
+            + reads
+            + " | samtools sort -@"
+            + threads
+            + " > "
+            + bam
+        )
+        try:
+            subprocess.run(
+                command,
+                shell=True,
+                timeout=300,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.TimeoutExpired:
+            print("fail to map reads to contig: " + asm_cns)
+            return
+
+        # run wtpoa-cns to get polished contig
+        cns_tmp = asm_cns + ".tmp"
+        command = (
+            "samtools view -F0x900 "
+            + bam
+            + " | wtpoa-cns -t "
+            + threads
+            + " -d "
+            + asm_cns
+            + " -i - -fo "
+            + cns_tmp
+        )
+        try:
+            subprocess.run(
+                command,
+                shell=True,
+                timeout=300,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.TimeoutExpired:
+            print("fail to polish contig: " + asm_cns)
+            return
+        if check_exist(cns_tmp):
+            os.rename(cns_tmp, asm_cns)
+            os.remove(bam)
+        else:
+            break
+        k = k + 1
+        if k >= polish_iterations:
+            break
+    if check_exist(asm_cns):
+        return asm_cns
+    else:
+        print("polishing failed for " + asm_cns + "\n")
+    return None
+
+
+def run_flye_assembly(sv_reads, asm_dir, contig_name, thread, presets):
+    """Run Flye assembly"""
+    if presets == "pacbio":
+        presets_flye = "--pacbio-raw"
+    else:
+        presets_flye = "--nano-raw"
+
+    tmp_out_dir = os.path.join(asm_dir, contig_name)
+    mkdir(tmp_out_dir)
+    try:
+        subprocess.call(
+            [
+                "flye",
+                presets_flye,
+                sv_reads,
+                "--out-dir",
+                tmp_out_dir,
+                "--thread",
+                str(thread),
+                "--iterations",
+                "0",
+            ]
+        )
+    except Exception as e:
+        print(e)
+        print("Assembly failed, exiting...")
+        return
+    # rename contigs
+    contig_path = os.path.join(tmp_out_dir, "assembly.fasta")
+    contig_path_new = os.path.join(asm_dir, contig_name + ".cns.fa")
+    if check_exist(contig_path):
+        os.rename(contig_path, contig_path_new)
+        # remove tmp files
+        shutil.rmtree(tmp_out_dir)
+        return contig_path_new
+    else:
+        print("assembly failed")
+        return None
+
+
+def run_wtdbg2_assembly(sv_reads, asm_dir, contig_name, thread, presets):
+    """Run wtdbg2 assembly"""
+    if presets == "pacbio":
+        presets_wtdbg2 = "rs"
+    else:
+        presets_wtdbg2 = "ont"
+    prefix = sv_reads.replace(".reads.fa", "")
+    try:
+        subprocess.run(
+            [
+                "wtdbg2",
+                "-x",
+                presets_wtdbg2,
+                "-q",
+                "-AS",
+                "1",
+                "-g",
+                "30k",
+                "-t",
+                str(thread),
+                "-i",
+                sv_reads,
+                "-fo",
+                prefix,
+            ],
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        print("fail to build contig layout for contig: " + contig_name)
+        return
+    except Exception as e:
+        print(e)
+        print("wtdbg2 failed, exiting...")
+        return None
+
+    # derive consensus
+    contig_layout = prefix + ".ctg.lay.gz"
+    if check_exist(contig_layout):
+        cns_thread = str(min(thread, 4))
+        consensus = prefix + ".cns.fa"
+        try:
+            subprocess.run(
+                [
+                    "wtpoa-cns",
+                    "-q",
+                    "-t",
+                    cns_thread,
+                    "-i",
+                    contig_layout,
+                    "-fo",
+                    consensus,
+                ],
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            print("fail to assemble contig: " + contig_name)
+            return None
+
+    if check_exist(consensus):
+        consensus_rename = os.path.join(asm_dir, contig_name + ".cns.fa")
+        os.rename(consensus, consensus_rename)
+        return consensus_rename
+    else:
+        return None
+
+
+def prep_assembly_inputs(
     vcf_parsed, out, sample_name, bam, raw_reads, reads_dir, read_type="sv"
 ):
     """Prepare reads for local assembly"""
@@ -103,7 +381,7 @@ def prep_assembly(
                 read_list = entry[8].split(",")
                 for read in read_list:
                     output.write(read + "\n")
-    else:
+    else:  # TODO: think about using this for assembly, filter for cigar reads
         window = 1000
         samfile = pysam.AlignmentFile(bam, "rb")
         read_ids = os.path.join(out, sample_name + ".id")
@@ -182,196 +460,46 @@ def prep_assembly(
     os.remove(subset_fa_reorder)
 
 
-def run_flye(args):
-    sv_reads = args[0]
-    asm_dir = args[1]
-    contig_name = args[2]
-    thread = args[3]
-    presets = args[4]
-    polish = args[5]
+# def run_flye(args):
+#     sv_reads = args[0]
+#     asm_dir = args[1]
+#     contig_name = args[2]
+#     thread = args[3]
+#     presets = args[4]
+#     polish = args[5]
 
-    if presets == "pacbio":
-        presets_flye = "--pacbio-raw"
-    else:
-        presets_flye = "--nano-raw"
+#     if presets == "pacbio":
+#         presets_flye = "--pacbio-raw"
+#     else:
+#         presets_flye = "--nano-raw"
 
-    tmp_out_dir = os.path.join(asm_dir, contig_name)
-    mkdir(tmp_out_dir)
-    try:
-        subprocess.call(
-            [
-                "flye",
-                presets_flye,
-                sv_reads,
-                "--out-dir",
-                tmp_out_dir,
-                "--thread",
-                str(thread),
-                "--iterations",
-                str(polish),
-            ]
-        )
-    except Exception as e:
-        print(e)
-        print("Assembly failed, exiting...")
-        return
-    # rename contigs
-    contig_path = os.path.join(tmp_out_dir, "assembly.fasta")
-    contig_path_new = os.path.join(asm_dir, contig_name + ".cns.fa")
-    if os.path.isfile(contig_path):
-        os.rename(contig_path, contig_path_new)
-    # remove tmp files
-    shutil.rmtree(tmp_out_dir)
-
-
-def run_wtdbg2(args):
-    sv_reads = args[0]
-    asm_dir = args[1]
-    contig_name = args[2]
-    thread = args[3]
-    presets = args[4]
-    polish = args[5]
-
-    if presets == "pacbio":
-        presets_wtdbg2 = "rs"
-        presets_minimap2 = "map-pb"
-    else:
-        presets_wtdbg2 = "ont"
-        presets_minimap2 = "map-ont"
-
-    prefix = sv_reads.replace(".reads.fa", "")
-    try:
-        subprocess.run(
-            [
-                "wtdbg2",
-                "-x",
-                presets_wtdbg2,
-                "-q",
-                "-AS",
-                "1",
-                "-g",
-                "30k",
-                "-t",
-                str(thread),
-                "-i",
-                sv_reads,
-                "-fo",
-                prefix,
-            ],
-            timeout=300,
-        )
-    except subprocess.TimeoutExpired:
-        print("fail to build contig layout for contig: " + contig_name)
-        return
-
-    contig_layout = prefix + ".ctg.lay.gz"
-    if check_exist(contig_layout):
-        # derive consensus
-        cns_thread = str(min(thread, 4))
-        consensus = prefix + ".raw.fa"
-        try:
-            subprocess.run(
-                [
-                    "wtpoa-cns",
-                    "-q",
-                    "-t",
-                    cns_thread,
-                    "-i",
-                    contig_layout,
-                    "-fo",
-                    consensus,
-                ],
-                timeout=300,
-            )
-        except subprocess.TimeoutExpired:
-            print("fail to assemble contig: " + contig_name)
-            return
-        if check_exist(consensus):
-            consensus_final = asm_dir + "/" + contig_name + ".cns.fa"
-            if polish > 0:
-                polish_contig(
-                    prefix,
-                    sv_reads,
-                    consensus,
-                    consensus_final,
-                    thread,
-                    presets_minimap2,
-                    polish,
-                    contig_name,
-                )
-            else:
-                # move raw consensus to asm dir
-                os.rename(consensus, consensus_final)
-        else:
-            print("Initial assembly fail for " + prefix + "\n")
-    else:
-        print("Build contig layout fail for " + prefix + "\n")
-
-
-def polish_contig(
-    prefix, reads, raw_contig, polished_contig, thread, preset, round, contig_name
-):
-    # polish consensus
-    polish_thread = str(min(thread, 4))
-    bam = raw_contig + ".bam"
-    k = 0
-    while True:
-        tmp_contig = raw_contig + ".tmp"
-        command = (
-            "minimap2 -t "
-            + polish_thread
-            + " -ax "
-            + preset
-            + " -r2k "
-            + raw_contig
-            + " "
-            + reads
-            + " | samtools sort -@"
-            + polish_thread
-            + " > "
-            + bam
-        )
-        try:
-            subprocess.run(
-                command,
-                shell=True,
-                timeout=300,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
-            )
-        except subprocess.TimeoutExpired:
-            print("fail to map reads to contig: " + contig_name)
-            return
-        command = (
-            "samtools view -F0x900 "
-            + bam
-            + " | wtpoa-cns -t "
-            + polish_thread
-            + " -d "
-            + raw_contig
-            + " -i - -fo "
-            + tmp_contig
-        )
-        try:
-            subprocess.run(
-                command,
-                shell=True,
-                timeout=300,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
-            )
-        except subprocess.TimeoutExpired:
-            print("fail to polish contig: " + contig_name)
-            return
-        raw_contig = tmp_contig
-        k = k + 1
-        if k >= round:
-            break
-    if os.path.isfile(tmp_contig) and os.stat(tmp_contig).st_size != 0:
-        os.rename(tmp_contig, polished_contig)
-    else:
-        print("polishing failed for " + contig_name + "\n")
-    return
+#     tmp_out_dir = os.path.join(asm_dir, contig_name)
+#     mkdir(tmp_out_dir)
+#     try:
+#         subprocess.call(
+#             [
+#                 "flye",
+#                 presets_flye,
+#                 sv_reads,
+#                 "--out-dir",
+#                 tmp_out_dir,
+#                 "--thread",
+#                 str(thread),
+#                 "--iterations",
+#                 str(polish),
+#             ]
+#         )
+#     except Exception as e:
+#         print(e)
+#         print("Assembly failed, exiting...")
+#         return
+#     # rename contigs
+#     contig_path = os.path.join(tmp_out_dir, "assembly.fasta")
+#     contig_path_new = os.path.join(asm_dir, contig_name + ".cns.fa")
+#     if os.path.isfile(contig_path):
+#         os.rename(contig_path, contig_path_new)
+#     # remove tmp files
+#     shutil.rmtree(tmp_out_dir)
 
 
 def extract_reads(reads, list, out):

--- a/TELR_input.py
+++ b/TELR_input.py
@@ -39,19 +39,19 @@ def get_args():
 
     # optional
     optional.add_argument(
-        "--align_method",
+        "--aligner",
         type=str,
         help="choose method for read alignment, please provide 'nglmr' or 'minimap2' (default = 'nglmr')",
         required=False,
     )
     optional.add_argument(
-        "--asm_method",
+        "--assembler",
         type=str,
         help="Choose the method to be used for local contig assembly step, please provide 'wtdbg2' or 'flye' (default = 'wtdbg2')",
         required=False,
     )
     optional.add_argument(
-        "--polish_method",
+        "--polisher",
         type=str,
         help="Choose the method to be used for local contig polishing step, please provide 'wtdbg2' or 'flye' (default = 'wtdbg2')",
         required=False,
@@ -101,7 +101,7 @@ def get_args():
     optional.add_argument(
         "--flank_len",
         type=int,
-        help="flanking sequence length (default = '500bp')",
+        help="flanking sequence length (default = '500')",
         required=False,
     )
     optional.add_argument(
@@ -149,21 +149,21 @@ def get_args():
         sys.exit(1)
 
     # check if optional arguments are valid
-    if args.align_method is None:
-        args.align_method = "nglmr"
-    elif args.align_method not in ["nglmr", "minimap2"]:
+    if args.aligner is None:
+        args.aligner = "nglmr"
+    elif args.aligner not in ["nglmr", "minimap2"]:
         print("Please provide a valid alignment method (nglmr/minimap2), exiting...")
         sys.exit(1)
 
-    if args.asm_method is None:
-        args.asm_method = "wtdbg2"
-    elif args.asm_method not in ["wtdbg2", "flye"]:
+    if args.assembler is None:
+        args.assembler = "wtdbg2"
+    elif args.assembler not in ["wtdbg2", "flye"]:
         print("Please provide a valid assembly method (wtdbg2/flye), exiting...")
         sys.exit(1)
 
-    if args.polish_method is None:
-        args.polish_method = "wtdbg2"
-    elif args.polish_method not in ["wtdbg2", "flye"]:
+    if args.polisher is None:
+        args.polisher = "wtdbg2"
+    elif args.polisher not in ["wtdbg2", "flye"]:
         print("Please provide a valid polish method (wtdbg2/flye), exiting...")
         sys.exit(1)
 

--- a/TELR_input.py
+++ b/TELR_input.py
@@ -39,17 +39,21 @@ def get_args():
 
     # optional
     optional.add_argument(
-        "-m",
         "--align_method",
         type=str,
         help="choose method for read alignment, please provide 'nglmr' or 'minimap2' (default = 'nglmr')",
         required=False,
     )
     optional.add_argument(
-        "-s",
         "--asm_method",
         type=str,
-        help="Choose the method to be used for local contig assembly and polishing step, please provide 'wtdbg2' or 'flye' (default = 'wtdbg2')",
+        help="Choose the method to be used for local contig assembly step, please provide 'wtdbg2' or 'flye' (default = 'wtdbg2')",
+        required=False,
+    )
+    optional.add_argument(
+        "--polish_method",
+        type=str,
+        help="Choose the method to be used for local contig polishing step, please provide 'wtdbg2' or 'flye' (default = 'wtdbg2')",
         required=False,
     )
     optional.add_argument(
@@ -61,9 +65,9 @@ def get_args():
     )
     optional.add_argument(
         "-p",
-        "--polish",
+        "--polish_iterations",
         type=int,
-        help="rounds of contig polishing (default = 1)",
+        help="iterations of contig polishing (default = 1)",
         required=False,
     )
     optional.add_argument(
@@ -100,12 +104,6 @@ def get_args():
         help="flanking sequence length (default = '500bp')",
         required=False,
     )
-    # optional.add_argument(
-    #     "--both_flanks",
-    #     action="store_true",
-    #     help="If provided then allow single flank support (default: requires both flanks to be aligned to reference genome)",
-    #     required=False,
-    # )
     optional.add_argument(
         "--different_contig_name",
         action="store_true",
@@ -150,23 +148,35 @@ def get_args():
         logging.exception("Can not open input file: " + args.library)
         sys.exit(1)
 
+    # check if optional arguments are valid
     if args.align_method is None:
         args.align_method = "nglmr"
     elif args.align_method not in ["nglmr", "minimap2"]:
-        print("Please provide a valid alignment method, exiting...")
+        print("Please provide a valid alignment method (nglmr/minimap2), exiting...")
         sys.exit(1)
 
     if args.asm_method is None:
         args.asm_method = "wtdbg2"
     elif args.asm_method not in ["wtdbg2", "flye"]:
-        print("Please provide a valid asm_method")
+        print("Please provide a valid assembly method (wtdbg2/flye), exiting...")
+        sys.exit(1)
+
+    if args.polish_method is None:
+        args.polish_method = "wtdbg2"
+    elif args.polish_method not in ["wtdbg2", "flye"]:
+        print("Please provide a valid polish method (wtdbg2/flye), exiting...")
         sys.exit(1)
 
     if args.presets is None:
         args.presets = "pacbio"
     elif args.presets not in ["pacbio", "ont"]:
-        print("Please provide a valid preset option")
+        print("Please provide a valid preset option (pacbio/ont), exiting...")
         sys.exit(1)
+
+    if args.polish_iterations is None:
+        args.polish_iterations = 1
+    elif args.polish_iterations < 1:
+        print("Please provide a valid number of iterations for polishing, exiting...")
 
     # sets up out dir variable
     if args.out is None:
@@ -179,9 +189,6 @@ def get_args():
 
     if args.flank_len is None:
         args.flank_len = 500
-
-    if args.polish is None:
-        args.polish = 1
 
     if args.gap is None:
         args.gap = 20

--- a/TELR_liftover.py
+++ b/TELR_liftover.py
@@ -48,21 +48,21 @@ def get_args(program_version, arguments=sys.argv[1:]):
         "-l",
         "--flank_len",
         type=int,
-        help="flanking sequence length (default = '500bp')",
+        help="flanking sequence length (default = '500')",
         required=False,
     )
     parser.add_argument(
         "-g",
         "--flank_gap_max",
         type=int,
-        help="maximum gap size between 5p and 3p flanking sequence alignments (default = '50bp')",
+        help="maximum gap size between 5p and 3p flanking sequence alignments (default = '50')",
         required=False,
     )
     parser.add_argument(
         "-p",
         "--flank_overlap_max",
         type=int,
-        help="maximum overlap size between 5p and 3p flanking sequence alignments (default = '50bp')",
+        help="maximum overlap size between 5p and 3p flanking sequence alignments (default = '50')",
         required=False,
     )
     parser.add_argument(

--- a/TELR_sv.py
+++ b/TELR_sv.py
@@ -78,9 +78,7 @@ def vcf_parse_filter(
     # merge entries
     vcf_merged = vcf_in + ".merged.tmp.tsv"
     merge_vcf(vcf_filtered, vcf_merged)
-
     os.rename(vcf_merged, vcf_out)
-    # os.remove(vcf_parsed_tmp)
 
 
 def merge_vcf(vcf_in, vcf_out, window=20):

--- a/TELR_te.py
+++ b/TELR_te.py
@@ -26,10 +26,10 @@ def annotate_contig(
     loci_eval,
 ):
     logging.info("Annotate contigs...")
-    if presets == "ont":
-        presets = "map-ont"
-    else:
+    if presets == "pacbio":
         presets = "map-pb"
+    else:
+        presets = "map-ont"
 
     all_loci = create_loci_set(vcf_parsed)
     assembly_passed_loci = set()
@@ -43,7 +43,7 @@ def annotate_contig(
                 with open(assembly, "r") as handle:
                     records = SeqIO.parse(handle, "fasta")
                     for record in records:
-                        if record.id == "ctg1":
+                        if record.id == "ctg1" or record.id == "contig_1":
                             record.id = locus
                             record.description = "len=" + str(len(record.seq))
                             SeqIO.write(record, MERGE, "fasta")

--- a/TELR_utility.py
+++ b/TELR_utility.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta
+import subprocess
 
 
 def rm_file(file):
@@ -53,3 +54,10 @@ def report_bad_loci(set_raw, set_filtered, report, message):
         for locus in set_raw:
             if locus not in set_filtered:
                 output.write("\t".join([locus, message]) + "\n")
+
+
+def get_cmd_output(cmd_list):
+    """get output from subprocess"""
+    output = subprocess.check_output(cmd_list)
+    output = output.decode("utf-8")
+    return output

--- a/docs/02_Usage.md
+++ b/docs/02_Usage.md
@@ -18,19 +18,23 @@ required arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -m ALIGN_METHOD, --align_method ALIGN_METHOD
+  --align_method ALIGN_METHOD
                         choose method for read alignment, please provide
                         'nglmr' or 'minimap2' (default = 'nglmr')
-  -s ASM_METHOD, --asm_method ASM_METHOD
+  --asm_method ASM_METHOD
                         Choose the method to be used for local contig assembly
-                        and polishing step, please provide 'wtdbg2' or 'flye'
+                        step, please provide 'wtdbg2' or 'flye' (default =
+                        'wtdbg2')
+  --polish_method POLISH_METHOD
+                        Choose the method to be used for local contig
+                        polishing step, please provide 'wtdbg2' or 'flye'
                         (default = 'wtdbg2')
   -x PRESETS, --presets PRESETS
                         parameter presets for different sequencing
                         technologies, please provide 'pacbio' or 'ont'
                         (default = 'pacbio')
-  -p POLISH, --polish POLISH
-                        rounds of contig polishing (default = 1)
+  -p POLISH_ITERATIONS, --polish_iterations POLISH_ITERATIONS
+                        iterations of contig polishing (default = 1)
   -o OUT, --out OUT     directory to output data (default = '.')
   -t THREAD, --thread THREAD
                         max cpu threads to use (default = '1')
@@ -40,7 +44,7 @@ optional arguments:
                         max overlap size for flanking sequence alignment
                         (default = '20')
   --flank_len FLANK_LEN
-                        flanking sequence length (default = '500bp')
+                        flanking sequence length (default = '500')
   --different_contig_name
                         If provided then TELR does not require the contig name
                         to match before and after annotation liftover
@@ -63,15 +67,16 @@ python3 telr.py -i (--reads) <reads in fasta/fastq format or read alignments in 
 
 ## Optional arguments
 In addition to the required program options listed above, there are some optional arguments. The full list of program options with descriptions can also be obtained by running `telr.py -h`.
-- `-m (--align_method) <arg>` Method for read alignment, please provide 'nglmr' or or 'minimap2' (default = 'nglmr').
-- `-s (--asm_method) <arg>` Method for for local contig assembly and polishing step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
-- `-x (--presets) <arg>` Preset for different sequencing technologies, please provide 'pacbio' or 'ont' (default = 'pacbio').
-- `-p (--polish) <int>` Iterations of contig polishing (default = '1').
-- `-o (--out) <arg>` Output directory (default = '.').
-- `-t (--thread) <int>` Maximum cpu threads to use (default = '1').
-- `-g (--gap) <int>` Maximum gap size between sequence alignments of two contig flanks (default= '50').
-- `-v (--overlap) <int>` Maximum overlap size between sequence alignments of two contig flanks (default= '50').
+- `-x/--presets <str>` Preset for different sequencing technologies, please provide 'pacbio' or 'ont' (default = 'pacbio').
+- `--align_method <str>` Method for read alignment, please provide 'nglmr' or or 'minimap2' (default = 'nglmr').
+- `--asm_method <str>` Method for for local contig assembly step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
+- `--polish_method <str>` Method for for local contig polishing step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
+- `-p/--polish_iterations <int>` Iterations of contig polishing (default = '1').
+- `-o/--out <str>` Output directory (default = '.').
+- `-t/--thread <int>` Maximum cpu threads to use (default = '1').
+- `-g/--gap <int>` Maximum gap size between sequence alignments of two contig flanks (default= '50').
+- `-v/--overlap <int>` Maximum overlap size between sequence alignments of two contig flanks (default= '50').
 - `--flank_len <int>` flanking sequence length in the TELR assembled contigs (default= '500').
 - `--different_contig_name` If provided then TELR does not require the contig name to match before and after annotation liftover (default: require contig name to be the same before and after liftover).
 - `--minimap2_family` If provided then minimap2 will be used to annotate TE families in the assembled contigs (default: use repeatmasker for contig TE annotation).
-- `-k (--keep_files)` If provided then all intermediate files will be kept (default: remove intermediate files).
+- `-k/--keep_files` If provided then all intermediate files will be kept (default: remove intermediate files).

--- a/docs/02_Usage.md
+++ b/docs/02_Usage.md
@@ -18,12 +18,16 @@ required arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -m METHOD, --method METHOD
-                        method for read alignment, please provide 'nglmr' or
-                        'minimap2' (default = 'nglmr')
+  -m ALIGN_METHOD, --align_method ALIGN_METHOD
+                        choose method for read alignment, please provide
+                        'nglmr' or 'minimap2' (default = 'nglmr')
+  -s ASM_METHOD, --asm_method ASM_METHOD
+                        Choose the method to be used for local contig assembly
+                        and polishing step, please provide 'wtdbg2' or 'flye'
+                        (default = 'wtdbg2')
   -x PRESETS, --presets PRESETS
                         parameter presets for different sequencing
-                        technologies, please provide 'ont' or 'pacbio'
+                        technologies, please provide 'pacbio' or 'ont'
                         (default = 'pacbio')
   -p POLISH, --polish POLISH
                         rounds of contig polishing (default = 1)
@@ -31,12 +35,12 @@ optional arguments:
   -t THREAD, --thread THREAD
                         max cpu threads to use (default = '1')
   -g GAP, --gap GAP     max gap size for flanking sequence alignment (default
-                        = '50')
+                        = '20')
   -v OVERLAP, --overlap OVERLAP
                         max overlap size for flanking sequence alignment
-                        (default = '50')
+                        (default = '20')
   --flank_len FLANK_LEN
-                        flanking sequence length in the TELR assembled contigs (default = '500')
+                        flanking sequence length (default = '500bp')
   --different_contig_name
                         If provided then TELR does not require the contig name
                         to match before and after annotation liftover
@@ -59,9 +63,10 @@ python3 telr.py -i (--reads) <reads in fasta/fastq format or read alignments in 
 
 ## Optional arguments
 In addition to the required program options listed above, there are some optional arguments. The full list of program options with descriptions can also be obtained by running `telr.py -h`.
-- `-m (--method) <arg>` Method for read alignment, please provide 'nglmr' or or 'minimap2' (default = 'nglmr').
-- `-x (--presets) <arg>` Preset for different sequencing technologies, please provide 'ont' or 'pacbio' (default = 'pacbio').
-- `-p (--polish) <int>` Rounds of contig polishing using polisher from [wtdbg2](https://github.com/ruanjue/wtdbg2) (default = 1).
+- `-m (--align_method) <arg>` Method for read alignment, please provide 'nglmr' or or 'minimap2' (default = 'nglmr').
+- `-s (--asm_method) <arg>` Method for for local contig assembly and polishing step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
+- `-x (--presets) <arg>` Preset for different sequencing technologies, please provide 'pacbio' or 'ont' (default = 'pacbio').
+- `-p (--polish) <int>` Iterations of contig polishing (default = '1').
 - `-o (--out) <arg>` Output directory (default = '.').
 - `-t (--thread) <int>` Maximum cpu threads to use (default = '1').
 - `-g (--gap) <int>` Maximum gap size between sequence alignments of two contig flanks (default= '50').

--- a/docs/02_Usage.md
+++ b/docs/02_Usage.md
@@ -18,15 +18,13 @@ required arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --align_method ALIGN_METHOD
-                        choose method for read alignment, please provide
+  --aligner ALIGNER     choose method for read alignment, please provide
                         'nglmr' or 'minimap2' (default = 'nglmr')
-  --asm_method ASM_METHOD
+  --assembler ASSEMBLER
                         Choose the method to be used for local contig assembly
                         step, please provide 'wtdbg2' or 'flye' (default =
                         'wtdbg2')
-  --polish_method POLISH_METHOD
-                        Choose the method to be used for local contig
+  --polisher POLISHER   Choose the method to be used for local contig
                         polishing step, please provide 'wtdbg2' or 'flye'
                         (default = 'wtdbg2')
   -x PRESETS, --presets PRESETS
@@ -68,9 +66,9 @@ python3 telr.py -i (--reads) <reads in fasta/fastq format or read alignments in 
 ## Optional arguments
 In addition to the required program options listed above, there are some optional arguments. The full list of program options with descriptions can also be obtained by running `telr.py -h`.
 - `-x/--presets <str>` Preset for different sequencing technologies, please provide 'pacbio' or 'ont' (default = 'pacbio').
-- `--align_method <str>` Method for read alignment, please provide 'nglmr' or or 'minimap2' (default = 'nglmr').
-- `--asm_method <str>` Method for for local contig assembly step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
-- `--polish_method <str>` Method for for local contig polishing step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
+- `--aligner <str>` Method for read alignment, please provide 'nglmr' or or 'minimap2' (default = 'nglmr').
+- `--assembler <str>` Method for for local contig assembly step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
+- `--polisher <str>` Method for for local contig polishing step, please provide 'wtdbg2' or or 'flye' (default = 'wtdbg2').
 - `-p/--polish_iterations <int>` Iterations of contig polishing (default = '1').
 - `-o/--out <str>` Output directory (default = '.').
 - `-t/--thread <int>` Maximum cpu threads to use (default = '1').

--- a/telr.py
+++ b/telr.py
@@ -54,7 +54,7 @@ def main():
             tmp_dir,
             sample_name,
             args.thread,
-            args.align_method,
+            args.aligner,
             args.presets,
         )
     else:
@@ -85,8 +85,8 @@ def main():
     # Local assembly
     contig_dir = os.path.join(tmp_dir, "contig_assembly")
     merged_contigs, assembly_passed_loci = get_local_contigs(
-        asm_method=args.asm_method,
-        polish_method=args.polish_method,
+        assembler=args.assembler,
+        polisher=args.polisher,
         contig_dir=contig_dir,
         vcf_parsed=vcf_parsed,
         out=tmp_dir,

--- a/telr.py
+++ b/telr.py
@@ -54,7 +54,7 @@ def main():
             tmp_dir,
             sample_name,
             args.thread,
-            args.method,
+            args.align_method,
             args.presets,
         )
     else:
@@ -85,15 +85,16 @@ def main():
     # Local assembly
     contig_dir = os.path.join(tmp_dir, "contig_assembly")
     local_assembly(
-        contig_dir,
-        vcf_parsed,
-        tmp_dir,
-        sample_name,
-        bam,
-        fasta,
-        args.thread,
-        args.presets,
-        args.polish,
+        method=args.asm_method,
+        contig_dir=contig_dir,
+        vcf_parsed=vcf_parsed,
+        out=tmp_dir,
+        sample_name=sample_name,
+        bam=bam,
+        raw_reads=fasta,
+        thread=args.thread,
+        presets=args.presets,
+        polish_iterations=args.polish,
     )
 
     # Annotate contig for TE region


### PR DESCRIPTION
- Users can now:
    - Choose ngmlr or minimap2 as raw reads to reference aligner using `--aligner` option.
    - Choose wtdbg2 or flye as local contig assembler using `--assembler` option.
    - Choose wtdbg2 or flye as local contig polisher using `--polisher` option.
    - Choose number of iterations for local contig polishing using `-p/--polish_iterations` option.