### PR TITLE
Add options used in TE AF estimation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please use the [Github Issue page](https://github.com/bergmanlab/TELR/issues) if
 
 ## License
 
-Copyright (c) 2020 Shunhua Han, Guilherme Dias and Casey M. Bergman
+Copyright (c) 2021 Shunhua Han, Guilherme Dias and Casey M. Bergman
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/TELR_input.py
+++ b/TELR_input.py
@@ -105,6 +105,18 @@ def get_args():
         required=False,
     )
     optional.add_argument(
+        "--af_flank_interval_size",
+        type=int,
+        help="interval size to be used for allele frequency estimation (default = '100')",
+        required=False,
+    )
+    optional.add_argument(
+        "--af_flank_offset",
+        type=int,
+        help="offset to be used for allele frequency estimation (default = '200')",
+        required=False,
+    )
+    optional.add_argument(
         "--different_contig_name",
         action="store_true",
         help="If provided then TELR does not require the contig name to match before and after annotation liftover (default: require contig name to be the same before and after liftover)",
@@ -189,6 +201,12 @@ def get_args():
 
     if args.flank_len is None:
         args.flank_len = 500
+
+    if args.af_flank_interval_size is None:
+        args.af_flank_interval_size = 100
+
+    if args.af_flank_offset is None:
+        args.af_flank_offset = 200
 
     if args.gap is None:
         args.gap = 20

--- a/TELR_input.py
+++ b/TELR_input.py
@@ -9,7 +9,7 @@ from TELR_utility import mkdir
 
 def get_args():
     parser = argparse.ArgumentParser(
-        description="Script to detect TEs in long read data"
+        description="Program for detecting non-reference TEs in long read data"
     )
     optional = parser._action_groups.pop()
     required = parser.add_argument_group("required arguments")

--- a/TELR_input.py
+++ b/TELR_input.py
@@ -105,15 +105,27 @@ def get_args():
         required=False,
     )
     optional.add_argument(
-        "--af_flank_interval_size",
+        "--af_flank_interval",
         type=int,
-        help="interval size to be used for allele frequency estimation (default = '100')",
+        help="5' and 3'flanking sequence interval size used for allele frequency estimation (default = '100')",
         required=False,
     )
     optional.add_argument(
         "--af_flank_offset",
         type=int,
-        help="offset to be used for allele frequency estimation (default = '200')",
+        help="5' and 3' flanking sequence offset size used for allele frequency estimation (default = '200')",
+        required=False,
+    )
+    optional.add_argument(
+        "--af_te_interval",
+        type=int,
+        help="5' and 3' te sequence interval size used for allele frequency estimation (default: whole te locus)",
+        required=False,
+    )
+    optional.add_argument(
+        "--af_te_offset",
+        type=int,
+        help="5' and 3' te sequence offset size used for allele frequency estimation (default: '0')",
         required=False,
     )
     optional.add_argument(
@@ -202,11 +214,20 @@ def get_args():
     if args.flank_len is None:
         args.flank_len = 500
 
-    if args.af_flank_interval_size is None:
-        args.af_flank_interval_size = 100
+    if args.af_flank_interval is None:
+        args.af_flank_interval = 100
 
     if args.af_flank_offset is None:
         args.af_flank_offset = 200
+
+    if args.af_te_interval:
+        if args.af_te_interval <= 0:
+            print(
+                "Please provide a valid interval size (positive integer) for allele frequency estimation, exiting..."
+            )
+
+    if args.af_te_offset:
+        args.af_te_offset = 0
 
     if args.gap is None:
         args.gap = 20

--- a/TELR_input.py
+++ b/TELR_input.py
@@ -216,18 +216,34 @@ def get_args():
 
     if args.af_flank_interval is None:
         args.af_flank_interval = 100
+    else:
+        if args.af_flank_interval <= 0:
+            print(
+                "Please provide a valid flanking sequence interval size (positive integer) for allele frequency estimation, exiting..."
+            )
+            sys.exit(1)
 
     if args.af_flank_offset is None:
         args.af_flank_offset = 200
+    else:
+        if args.af_flank_offset < 0:
+            print(
+                "Please provide a valid flanking sequence offset size (positive integer) for allele frequency estimation, exiting..."
+            )
 
     if args.af_te_interval:
         if args.af_te_interval <= 0:
             print(
-                "Please provide a valid interval size (positive integer) for allele frequency estimation, exiting..."
+                "Please provide a valid TE interval size (positive integer) for allele frequency estimation, exiting..."
             )
 
-    if args.af_te_offset:
+    if args.af_te_offset is None:
         args.af_te_offset = 0
+    else:
+        if args.af_te_offset < 0:
+            print(
+                "Please provide a valid TE offset size (positive integer) for allele frequency estimation, exiting..."
+            )
 
     if args.gap is None:
         args.gap = 20

--- a/TELR_te.py
+++ b/TELR_te.py
@@ -487,9 +487,10 @@ def realignment(args):
     os.remove(bam)
 
 
-def get_flank_cov(
-    bam, contig_name, contig_length, start, end, flank_len=100, offset=200
-):
+def get_flank_cov(bam, contig_name, contig_length, start, end, flank_len, offset):
+    """
+    Get the coverage of the flanking regions of a TE
+    """
     left_flank_present = True
     right_flank_present = True
     left_flank_cov = 0
@@ -540,8 +541,10 @@ def get_af(
     contig_te_annotation,
     contig_dir,
     vcf_parsed,
-    intervel_size,
-    offset,
+    flank_intervel_size,
+    flank_offset,
+    te_interval_size,
+    te_offset,
     presets,
     thread,
 ):
@@ -624,24 +627,28 @@ def get_af(
                     contig = os.path.join(contig_dir, contig_name + ".cns.ctg1.fa")
                     contig_length = get_contig_length(contig)
                     # get TE locus coverage
-                    te_cov = get_median_cov(bam, contig_name, start, end)
+                    # te_cov = get_median_cov(bam, contig_name, start, end)
+                    te_5p_cov, te_3p_cov, te_avg_cov = get_te_cov(
+                        bam, contig_name, start, end, te_interval_size, te_offset
+                    )
+
                     # get flanking coverage
-                    left_flank_cov, right_flank_cov, flank_cov = get_flank_cov(
+                    flank_5p_cov, flank_3p_cov, flank_avg_cov = get_flank_cov(
                         bam,
                         contig_name,
                         contig_length,
                         start,
                         end,
-                        intervel_size,
-                        offset,
+                        flank_intervel_size,
+                        flank_offset,
                     )
                     out_line = "\t".join(
                         entry
                         + [
-                            str(te_cov),
-                            str(left_flank_cov),
-                            str(right_flank_cov),
-                            str(flank_cov),
+                            str(te_avg_cov),
+                            str(flank_5p_cov),
+                            str(flank_3p_cov),
+                            str(flank_avg_cov),
                         ]
                     )
                     output.write(out_line + "\n")
@@ -665,6 +672,38 @@ def get_af(
     proc_time = time.time() - start_time
     logging.info("Allele frequency estimation finished in " + format_time(proc_time))
     return te_freq
+
+
+def get_te_cov(bam, contig_name, start, end, te_interval_size, te_offset):
+    """
+    Get TE locus coverage
+    """
+    te_5p_cov = 0
+    te_3p_cov = 0
+    te_cov = 0
+    whole_te_locus_cov = False
+    if te_interval_size:
+        if start + te_offset + te_interval_size < end:
+            te_5p_cov = get_median_cov(
+                bam,
+                contig_name,
+                start + te_offset,
+                start + te_offset + te_interval_size,
+            )
+            te_3p_cov = get_median_cov(
+                bam, contig_name, end - te_interval_size - te_offset, end - te_offset
+            )
+        else:
+            whole_te_locus_cov = True
+    else:
+        whole_te_locus_cov = True
+
+    if whole_te_locus_cov:
+        te_5p_cov = get_median_cov(bam, contig_name, start, end)
+        te_3p_cov = te_5p_cov
+
+    te_cov = (te_5p_cov + te_3p_cov) / 2
+    return te_5p_cov, te_3p_cov, te_cov
 
 
 def get_median_cov(bam, chr, start, end):

--- a/TELR_te.py
+++ b/TELR_te.py
@@ -540,6 +540,8 @@ def get_af(
     contig_te_annotation,
     contig_dir,
     vcf_parsed,
+    intervel_size,
+    offset,
     presets,
     thread,
 ):
@@ -610,8 +612,6 @@ def get_af(
 
     # analyze realignment and estimate coverage
     vcf_parsed_freq = vcf_parsed + ".freq"
-    flank_len = 100
-    offset = 200
     with open(vcf_parsed, "r") as input, open(vcf_parsed_freq, "w") as output:
         for line in input:
             entry = line.replace("\n", "").split("\t")
@@ -623,10 +623,17 @@ def get_af(
                     # get contig size
                     contig = os.path.join(contig_dir, contig_name + ".cns.ctg1.fa")
                     contig_length = get_contig_length(contig)
-                    # get TE coverage
+                    # get TE locus coverage
                     te_cov = get_median_cov(bam, contig_name, start, end)
+                    # get flanking coverage
                     left_flank_cov, right_flank_cov, flank_cov = get_flank_cov(
-                        bam, contig_name, contig_length, start, end, flank_len, offset
+                        bam,
+                        contig_name,
+                        contig_length,
+                        start,
+                        end,
+                        intervel_size,
+                        offset,
                     )
                     out_line = "\t".join(
                         entry

--- a/docs/02_Usage.md
+++ b/docs/02_Usage.md
@@ -2,10 +2,13 @@
 
 ## Command line help page
 ```
-usage: telr.py [-h] -i READS -r REFERENCE -l LIBRARY [-x PRESETS] [-p POLISH]
-               [-o OUT] [-t THREAD] [-g GAP] [-v OVERLAP] [-k]
+usage: telr.py [-h] -i READS -r REFERENCE -l LIBRARY [--aligner ALIGNER]
+               [--assembler ASSEMBLER] [--polisher POLISHER] [-x PRESETS]
+               [-p POLISH_ITERATIONS] [-o OUT] [-t THREAD] [-g GAP]
+               [-v OVERLAP] [--flank_len FLANK_LEN] [--different_contig_name]
+               [--minimap2_family] [-k]
 
-Script to detect TEs in long read data
+Program for detecting non-reference TEs in long read data
 
 required arguments:
   -i READS, --reads READS

--- a/docs/02_Usage.md
+++ b/docs/02_Usage.md
@@ -5,8 +5,11 @@
 usage: telr.py [-h] -i READS -r REFERENCE -l LIBRARY [--aligner ALIGNER]
                [--assembler ASSEMBLER] [--polisher POLISHER] [-x PRESETS]
                [-p POLISH_ITERATIONS] [-o OUT] [-t THREAD] [-g GAP]
-               [-v OVERLAP] [--flank_len FLANK_LEN] [--different_contig_name]
-               [--minimap2_family] [-k]
+               [-v OVERLAP] [--flank_len FLANK_LEN]
+               [--af_flank_interval AF_FLANK_INTERVAL]
+               [--af_flank_offset AF_FLANK_OFFSET]
+               [--af_te_interval AF_TE_INTERVAL] [--af_te_offset AF_TE_OFFSET]
+               [--different_contig_name] [--minimap2_family] [-k]
 
 Program for detecting non-reference TEs in long read data
 
@@ -46,6 +49,18 @@ optional arguments:
                         (default = '20')
   --flank_len FLANK_LEN
                         flanking sequence length (default = '500')
+  --af_flank_interval AF_FLANK_INTERVAL
+                        5' and 3'flanking sequence interval size used for
+                        allele frequency estimation (default = '100')
+  --af_flank_offset AF_FLANK_OFFSET
+                        5' and 3' flanking sequence offset size used for
+                        allele frequency estimation (default = '200')
+  --af_te_interval AF_TE_INTERVAL
+                        5' and 3' te sequence interval size used for allele
+                        frequency estimation (default: whole te locus)
+  --af_te_offset AF_TE_OFFSET
+                        5' and 3' te sequence offset size used for allele
+                        frequency estimation (default: '0')
   --different_contig_name
                         If provided then TELR does not require the contig name
                         to match before and after annotation liftover
@@ -78,6 +93,10 @@ In addition to the required program options listed above, there are some optiona
 - `-g/--gap <int>` Maximum gap size between sequence alignments of two contig flanks (default= '50').
 - `-v/--overlap <int>` Maximum overlap size between sequence alignments of two contig flanks (default= '50').
 - `--flank_len <int>` flanking sequence length in the TELR assembled contigs (default= '500').
+- `--af_flank_interval <int>` 5' and 3' flanking sequence interval size used for allele frequency estimation (default= '100').
+- `--af_flank_offset <int>` 5' and 3' flanking sequence offset size used for allele frequency estimation (default= '200').
+- `--af_te_interval <int>` 5' and 3' TE interval size used for allele frequency estimation (default: whole te locus).
+- `--af_te_offset <int>` 5' and 3' TE offset size used for allele frequency estimation (default= '0').
 - `--different_contig_name` If provided then TELR does not require the contig name to match before and after annotation liftover (default: require contig name to be the same before and after liftover).
 - `--minimap2_family` If provided then minimap2 will be used to annotate TE families in the assembled contigs (default: use repeatmasker for contig TE annotation).
 - `-k/--keep_files` If provided then all intermediate files will be kept (default: remove intermediate files).

--- a/telr.py
+++ b/telr.py
@@ -121,6 +121,8 @@ def main():
         contig_te_annotation,
         contig_dir,
         vcf_parsed,
+        args.af_flank_interval_size,
+        args.af_flank_offset,
         args.presets,
         args.thread,
     )

--- a/telr.py
+++ b/telr.py
@@ -121,8 +121,10 @@ def main():
         contig_te_annotation,
         contig_dir,
         vcf_parsed,
-        args.af_flank_interval_size,
+        args.af_flank_interval,
         args.af_flank_offset,
+        args.af_te_interval,
+        args.af_te_offset,
         args.presets,
         args.thread,
     )


### PR DESCRIPTION
- Includes new options for the TE allele frequency estimation step:
    - `--af_flank_interval` is used to control the size of 5' and 3' flanking sequence to be used for flank coverage estimation. The default value is 100bp.
    - `--af_flank_offset` is used to control the distance between 5' and 3' flanking sequence and TE boundary. The default value is 200bp.
    - `--af_te_interval` is used to control the size of 5' and 3' TE sequence to be used for coverage estimation. The default value is `None` which means the entire TE locus will be used for coverage estimation.
    - `--af_te_offset` is used to control the distance between 5' and 3' TE sequence and TE boundary. The default value is 0bp.
    - Under default mode (without specifying any parameters), TELR would behave the same way as before. I can change the default value for `--af_te_interval` and `--af_te_offset` if we can find a set of optimal values for TAF estimation.
    - If `--af_te_interval` is provided, TELR would first determine whether `te_start +  te_offset + af_te_interval < te_end` is true. If the result is true, then TELR would calculate 5' TE locus coverage and 3' TE locus coverage separately and return the average value as final TE locus coverage which will be used for TAF compute. If the result is false, then the whole TE locus will be used for coverage estimation and TAF compute.