### PR TITLE
Fix RM gff out of sort issue

### DIFF
--- a/src/telr/TELR_sv.py
+++ b/src/telr/TELR_sv.py
@@ -280,12 +280,19 @@ def filter_vcf(ins, ins_filtered, te_library, out, sample_name, thread, loci_eva
         print("Repeatmasking VCF insertion sequences failed, exiting...")
         sys.exit(1)
 
+    # sort RM gff
+    ins_rm_sort = os.path.join(
+        repeatmasker_dir, os.path.basename(ins_seqs) + ".out.sort.gff"
+    )
+    with open(ins_rm_sort, "w") as output:
+        subprocess.call(["bedtools", "sort", "-i", ins_repeatmasked], stdout=output)
+
     # merge RM gff
     ins_rm_merge = os.path.join(
         repeatmasker_dir, os.path.basename(ins_seqs) + ".out.merge.bed"
     )
     with open(ins_rm_merge, "w") as output:
-        subprocess.call(["bedtools", "merge", "-i", ins_repeatmasked], stdout=output)
+        subprocess.call(["bedtools", "merge", "-i", ins_rm_sort], stdout=output)
 
     # extract VCF sequences that contain TEs
     ins_te_loci = dict()

--- a/src/telr/TELR_te.py
+++ b/src/telr/TELR_te.py
@@ -297,9 +297,17 @@ def annotate_contig(
             print("Repeatmasking contig TE sequences failed, exiting...")
             sys.exit(1)
 
+        # sort RM gff
+        contig_te_repeatmasked_sort = os.path.join(
+            repeatmasker_dir, os.path.basename(te_fa) + ".out.sort.gff"
+        )
+        with open(contig_te_repeatmasked_sort, "w") as output:
+            subprocess.call(["bedtools", "sort", "-i", contig_te_repeatmasked], stdout=output)
+
+
         ## parse and merge
         te2contig_rm = out + "/" + sample_name + ".te2contig_rm.bed"
-        with open(contig_te_repeatmasked, "r") as input, open(
+        with open(contig_te_repeatmasked_sort, "r") as input, open(
             te2contig_rm, "w"
         ) as output:
             for line in input:


### PR DESCRIPTION
In some cases, the RepeatMasker output GFF file contains out of sort records, this commit fixes this issue.