### PR TITLE
Fix start out of range issue in assembly prep

### DIFF
--- a/src/telr/TELR_assembly.py
+++ b/src/telr/TELR_assembly.py
@@ -399,6 +399,8 @@ def prep_assembly_inputs(
                 ins_chr = entry[0]
                 ins_breakpoint = round((int(entry[1]) + int(entry[2])) / 2)
                 start = ins_breakpoint - window
+                if start < 0:
+                    start = 0
                 end = ins_breakpoint + window
                 reads = set()
                 # coverage = 0


### PR DESCRIPTION
- The assembly process in TELR identifies the SV breakpoint, extract reads around the breakpoint with a 1kb window on both sides, and does the assembly.
- When the SV breakpoint is located near the boundary of the chromosome contig, the start position (SV position - 1000) could be a negative integer. The previous version of TELR doesn't check whether this value is negative. This new patch fixes this issue.
- A future patch is needed to also do the same check for the end position.