### PR TITLE
Fix filename too long error

### DIFF
--- a/src/telr/TELR_liftover.py
+++ b/src/telr/TELR_liftover.py
@@ -1019,7 +1019,7 @@ def liftover(
             family = entry[3]
             strand = entry[5]
 
-            prefix = "_".join([chrom, str(start), str(end), family])
+            prefix = "_".join([chrom, str(start), str(end)])
             liftover_entry = {
                 "chrom": chrom,
                 "start": start,


### PR DESCRIPTION
Previously, the input json file created by TELR during the liftover process (from local assembled contig flanks to reference genome to identify insertion breakpoint) contains the TE family name. In some rare occasions, there are multiple TE families in one contig, causing the filename to exceed the OS threshold. This branch fixes the OS file name to long error.